### PR TITLE
feat: add support for biome-based block tinting

### DIFF
--- a/src/main/java/org/terasology/flowingliquids/rendering/primitives/BlockMeshGeneratorDebugLiquid.java
+++ b/src/main/java/org/terasology/flowingliquids/rendering/primitives/BlockMeshGeneratorDebugLiquid.java
@@ -21,6 +21,7 @@ import org.terasology.engine.world.block.BlockPart;
 import org.terasology.engine.world.block.shapes.BlockMeshPart;
 import org.terasology.engine.world.block.tiles.WorldAtlas;
 import org.terasology.flowingliquids.world.block.LiquidData;
+import org.terasology.nui.Color;
 
 /**
  * As the default block mesh generator does not allow the mesh to depend on
@@ -57,7 +58,7 @@ public class BlockMeshGeneratorDebugLiquid implements BlockMeshGenerator {
             if (isSideVisibleForBlockTypes(view.getBlock(side.getAdjacentPos(pos, new Vector3i())), block, side)) {
                 BlockMeshPart basePart = appearance.getPart(BlockPart.fromSide(side));
                 BlockMeshPart labelledPart = basePart.mapTexCoords(textureOffsets[fluidHeight], TEX_COORD_SCALE, 1);
-                labelledPart.appendTo(chunkMesh, view, x, y, z, ChunkMesh.RenderType.OPAQUE, ChunkVertexFlag.NORMAL);
+                labelledPart.appendTo(chunkMesh, view, x, y, z, ChunkMesh.RenderType.OPAQUE, Color.white, ChunkVertexFlag.NORMAL);
             }
         }
     }

--- a/src/main/java/org/terasology/flowingliquids/rendering/primitives/BlockMeshGeneratorLiquid.java
+++ b/src/main/java/org/terasology/flowingliquids/rendering/primitives/BlockMeshGeneratorLiquid.java
@@ -23,6 +23,8 @@ import org.terasology.engine.world.block.BlockPart;
 import org.terasology.engine.world.block.shapes.BlockMeshPart;
 import org.terasology.engine.world.block.tiles.WorldAtlas;
 import org.terasology.flowingliquids.world.block.LiquidData;
+import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
 
 /**
  * As the default block mesh generator does not allow the mesh to depend on
@@ -53,6 +55,7 @@ public class BlockMeshGeneratorLiquid implements BlockMeshGenerator {
         }
 
         ChunkMesh.RenderType renderType = ChunkMesh.RenderType.TRANSLUCENT;
+        Color colorCache = new Color();
 
         if (!block.isTranslucent()) {
             renderType = ChunkMesh.RenderType.OPAQUE;
@@ -72,10 +75,16 @@ public class BlockMeshGeneratorLiquid implements BlockMeshGenerator {
             Block adjacentBlock = view.getBlock(adjacentPos);
             boolean adjacentSuppressed = view.getBlock(adjacentPos.x, adjacentPos.y + 1, adjacentPos.z) == block;
             if (isSideVisibleForBlockTypes(adjacentBlock, adjacentSuppressed, block, full, suppressed, side)) {
-//                Vector4f colorOffset = block.calcColorOffsetFor(BlockPart.fromSide(side), biome);
                 BlockMeshPart basePart = appearance.getPart(BlockPart.fromSide(side));
                 BlockMeshPart loweredPart = lowerPart(side, basePart, renderHeight, suppressed, adjacentBlock == block);
-                loweredPart.appendTo(chunkMesh, view, x, y, z, renderType, vertexFlag);
+
+                Colorc colorOffset = block.getColorOffset(BlockPart.fromSide(side));
+                Colorc colorSource = block.getColorSource(BlockPart.fromSide(side)).calcColor(x, y, z);
+                colorCache.setRed(colorSource.rf() * colorOffset.rf())
+                    .setGreen(colorSource.gf() * colorOffset.gf())
+                    .setBlue(colorSource.bf() * colorOffset.bf())
+                    .setAlpha(colorSource.af() * colorOffset.af());
+                loweredPart.appendTo(chunkMesh, view, x, y, z, renderType, colorCache, vertexFlag);
             }
         }
     }


### PR DESCRIPTION
This updates FlowingLiquids to support block tinting as implemented in https://github.com/MovingBlocks/Terasology/pull/4828, which is required because FlowingLiquids has its own mesh generator for liquids.